### PR TITLE
Bugfix with message matcher

### DIFF
--- a/nonebot_plugin_orangedice/__init__.py
+++ b/nonebot_plugin_orangedice/__init__.py
@@ -20,11 +20,11 @@ __plugin_meta__ = PluginMetadata(
     ".log on/off/upload/clear 日志功能开启/关闭/上传/清除")
 
 MANAGER = GROUP_ADMIN | GROUP_OWNER
-roll = on_startswith(".r", priority=5)  # roll点
-log = on_startswith(".log", permission=MANAGER, priority=5)  # 日志相关指令
-log_msg = on_message(priority=6)  # 记录日志
-card = on_startswith(".st", priority=5)  # 作成人物卡
-roll_card = on_startswith(".ra", priority=4)  # 人物技能roll点
+roll = on_startswith(".r", priority=5, block=False)  # roll点
+log = on_startswith(".log", permission=MANAGER, priority=5, block=False)  # 日志相关指令
+log_msg = on_message(priority=6, block=False)  # 记录日志
+card = on_startswith(".st", priority=5, block=False)  # 作成人物卡
+roll_card = on_startswith(".ra", priority=4, block=False)  # 人物技能roll点
 
 driver = get_driver()
 plugin_config = Config.parse_obj(driver.config)


### PR DESCRIPTION
修复 当多个插件同时被安装时，本插件响应器优先级过高导致其他插件指令被本插件自动阻断传递 的bug（其实也[不算bug](https://v2.nonebot.dev/docs/tutorial/plugin/create-matcher#%E9%98%BB%E6%96%AD-block)）（基于0.2.0及以上不再使用本地文件存储，建议将其补充推送至0.2.0版本分支）